### PR TITLE
fix: add missing section tag to index.vue

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,4 +1,5 @@
 <template>
+  <section>
     <div>
       <logo/>
       <h1 class="title">NUXT</h1>


### PR DESCRIPTION
This PR adds the missing `<section>` tag in the index page template. (Thanks for the codesandbox template 🙌)

Resolves https://github.com/nuxt/codesandbox-nuxt/issues/5